### PR TITLE
Add Zig Build System Support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,13 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    _ = b.addModule("jaysan", .{
+        .root_source_file = b.path("./src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const exe_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@
 
 const std = @import("std");
 
-const json = struct {
+pub const json = struct {
     pub fn stringify(value: anytype, writer: std.io.AnyWriter) !void {
         const T = @TypeOf(value);
         if (isString(T, value)) {


### PR DESCRIPTION
This adds support for the Zig Build System by adding a module that can be used in other places. It also sets the `json` struct to `pub` so it can be accessed after being imported.